### PR TITLE
Use minetest.global_exists to check for mobs

### DIFF
--- a/checks/list_spawning_mobs.lua
+++ b/checks/list_spawning_mobs.lua
@@ -1,4 +1,4 @@
-if mobs and mobs.spawning_mobs then
+if minetest.global_exists("mobs") and mobs.spawning_mobs then
 	for name, def in pairs(mobs.spawning_mobs) do
 		print(name)
 	end


### PR DESCRIPTION
Because checking against globals as such is discouraged and triggers warnings.