### PR TITLE
Add descriptions for checks

### DIFF
--- a/check_names.lua
+++ b/check_names.lua
@@ -1,0 +1,13 @@
+-- List of descriptions for each of the check scripts
+
+qa_block.check_names = {
+	global_variables = "List suspicious global variables",
+	light_source_15 = "List nodes with light_source >= 15",
+	list_spawning_mobs = "List spawning mobs",
+	same_recipe = "Find duplicate crafting recipes",
+	unobtainable_items = "List (probably) unobtainable items",
+	is_ground_content = "List nodes with is_ground_content == true",
+	list_entities = "List entities",
+	no_item_description = "List items without description",
+	useless_items = "List (probably) useless items",
+}

--- a/smartfs_forms.lua
+++ b/smartfs_forms.lua
@@ -15,20 +15,30 @@ qa_block.fs = smartfs.create("qa_block:block", function(state)
 	end
 -- Listbox
 	local listbox = state:listbox(0,1,10,5.5,"fileslist")
-	for idx, file in ipairs(qa_block.get_checks_list()) do
-		listbox:addItem(file)
+	for c=1, #qa_block.checks_list do
+		local check = qa_block.checks_list[c]
+		local check_label
+		if check.description ~= nil then
+			check_label = check.description
+		else
+			check_label = check.id
+		end
+		listbox:addItem(check_label)
 	end
 
 	listbox:onDoubleClick(function(self,state, index)
-		qa_block.do_module(self:getItem(index))
+		local real_index = tonumber(index)
+		if real_index ~= nil then
+			qa_block.do_module(qa_block.checks_list[real_index].id)
+		end
 	end)
 
 -- Run Button 
 	local runbutton = state:button(1,6.5,2,0.5,"Run","Run")
 	runbutton:onClick(function(self)
-		local check = listbox:getSelectedItem() 
-		if check then
-			qa_block.do_module(check)
+		local check_id = tonumber(listbox:getSelected())
+		if check_id then
+			qa_block.do_module(qa_block.checks_list[check_id].id)
 		else
 			print("no check selected")
 		end


### PR DESCRIPTION
This PR adds short descriptions for all the checks, like “Find duplicate crafting recipes” for `same_recipe`. They are displayed both in the QA block and with `/qa_block ls`.
I also did some minor code cleanup, I hope you don't mind.