### PR TITLE
Add checker which checks for doc_items support

### DIFF
--- a/checks/no_doc_items_help.lua
+++ b/checks/no_doc_items_help.lua
@@ -1,0 +1,14 @@
+-- Checker for the [doc_items]: Lists items without a long description or usage help
+
+local t = {}
+for id, def in pairs(minetest.registered_items) do
+	if def._doc_items_create_entry ~= false and def.description ~= nil and def.description ~= "" and id ~= "air" and id ~= "ignore" and id ~= "unknown" then
+		if (not def._doc_items_longdesc) and (not def._doc_items_usagehelp) then
+			table.insert(t, id)
+		end
+	end
+end
+table.sort(t)
+for i=1, #t do
+	print(t[i])
+end


### PR DESCRIPTION
This adds a checker for modders which want to support `doc_items`.
It checks all items if they have basic help texts (long description or usage help) and lists those which doesn't have help. The check is very lightweight and does *not* add any dependencies to `qa_block`.

This is useful if you want to make sure your item documentation is complete. I've used it by myselves to check MineClone 2 help completion.

The `doc_items` mod can be found here as part of the Help modpack: https://forum.minetest.net/viewtopic.php?f=9&t=15912&p=240152