### PR TITLE
Add 2 checks: broken_recipe, list_groups

### DIFF
--- a/checks/broken_recipe.lua
+++ b/checks/broken_recipe.lua
@@ -1,0 +1,77 @@
+-- Find crafting recipes which require unknown items or groups
+
+-- If true, will also check groups
+local check_groups = true
+
+local modutils = dofile(minetest.get_modpath("qa_block").."/modutils.lua")
+
+local known_bad_items = {}
+local known_groups = {}
+local known_bad_groups = {}
+
+local function item_exists(itemstring)
+	if itemstring == "" then
+		return true
+	elseif minetest.registered_items[itemstring] then
+		return true
+	end
+	return false
+end
+
+local function group_exists(groupname)
+	return known_groups[groupname] == true
+end
+
+-- Get groups
+if check_groups then
+	for name, def in pairs(minetest.registered_items) do
+		if def.groups then
+			for g,r in pairs(def.groups) do
+				known_groups[g] = true
+			end
+		end
+	end
+end
+
+local check_item = function(itemstring, bad_item_msg, bad_group_msg, is_output)
+	local item = ItemStack(itemstring):get_name()
+	local modname = modutils.get_modname_by_itemname(item)
+	if modname ~= "group" then
+		if not item_exists(item) and not known_bad_items[item] then
+			known_bad_items[item] = true
+			print(bad_item_msg .. ": \"" .. item .. "\"")
+		end
+	elseif check_groups then
+		local groupstr = string.sub(item, 7)
+		local groups = string.split(groupstr, ",")
+		if is_output and #groups > 0 then
+			print(bad_group_msg .. ". Full string: \""..item.."\")")
+			return
+		end
+		for g=1, #groups do
+			local group = groups[g]
+			if not group_exists(group) and not known_bad_groups[group] then
+				print(bad_group_msg .. ": \"" .. group .. "\" (full string: \""..item.."\")")
+				known_bad_groups[group] = true
+			end
+		end
+	end
+end
+
+-- Check recipes for unknown items and groups
+for name, def in pairs(minetest.registered_items) do
+	local recipes_for_item = minetest.get_all_craft_recipes(name)
+	if recipes_for_item then
+		for id, recipe in pairs(recipes_for_item) do
+			if recipe.items then
+				for i=1, #recipe.items do
+					local item = recipe.items[i]
+					if item and item ~= "" then
+						check_item(item, "Unknown input item", "Input group without any items")
+					end
+				end
+			end
+		end
+	end
+end
+

--- a/checks/list_groups.lua
+++ b/checks/list_groups.lua
@@ -1,0 +1,44 @@
+-- Lists all the groups that items are in
+
+-- If true, will also list all items that are members of the group
+local list_group_members = false
+
+local all_groups = {}
+for id, def in pairs(minetest.registered_items) do
+	if def.groups then
+		for group, rating in pairs(def.groups) do
+			if rating ~= 0 then
+				if not all_groups[group] then
+					all_groups[group] = {}
+				end
+				table.insert(all_groups[group], id)
+			end
+		end
+	end
+end
+
+-- Sort groups
+local flat_groups = {}
+for group, _ in pairs(all_groups) do
+	table.insert(flat_groups, group)
+end
+table.sort(flat_groups)
+
+-- Output
+for g=1, #flat_groups do
+	local group = flat_groups[g]
+	local items = all_groups[group]
+	if list_group_members then
+		-- Print all groups and the group members
+		print("Group \""..group.."\":")
+		table.sort(items)
+		for i=1, #items do
+			-- Print item name and group rating
+			local def = minetest.registered_items[items[i]]
+			print("  " .. items[i] .. " (" .. def.groups[group]..")")
+		end
+	else
+		-- Print groups only
+		print("Group \""..group.."\": "..(#items).." item(s)")
+	end
+end


### PR DESCRIPTION
I added two new checks:

* `broken_recipe`: Checks whether crafting recipes contain unknown items or groups and lists offending inputs (an “unknown group” is defined as a group that is not used by any registered item)
* `list_groups`: Lists all groups

Note that due to a limitation of the API, `broken_recipe` can only detect broken recipes when at least the output item is valid.