### PR TITLE
Add scripts for listing fuel and cooking recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ https://forum.minetest.net/viewtopic.php?f=11&t=15759
 - global_variables - List suspicious global variables
 - graphviz_recipes_all - Make a graphviz .dot file of all items in a recipe dependency tree
 - is_ground_content - This checker lists all nodes for which is_ground_content == true
+- list_cooking_recipes - List all the registered cooking recipes
 - list_entities - Lists all the registered entities (except builtin)
+- list_fuels - List all the registered fuel recipes
 - list_spawning_mobs - List entities that are mobs from mobs_redo or compatible framework
 - no_doc_items_help - Lists all items without item usage help or long description
 - no_item_description - Lists all items without description

--- a/checks/list_cooking_recipes.lua
+++ b/checks/list_cooking_recipes.lua
@@ -1,0 +1,23 @@
+-- List all registered cooking recipes (from core.register_craft)
+
+print("Registered cooking recipes:")
+local recipes = {}
+for itemstring, def in pairs(minetest.registered_items) do
+	local input = {
+		method = "cooking",
+		items = { itemstring },
+	}
+	local res = minetest.get_craft_result(input)
+	if res and res.time > 0 then
+		table.insert(recipes, {itemstring, res.item, res.time})
+	end
+end
+local sort_by_input = function(v1, v2)
+	return v1[1] < v2[1]
+end
+table.sort(recipes, sort_by_input)
+for r=1, #recipes do
+	-- Print cooking recipe, displaying the item to be cooked, the item after cooking, and the cook time
+	print(string.format("%s -> %s (cooktime=%d)", recipes[r][1], recipes[r][2]:to_string(), recipes[r][3]))
+end
+

--- a/checks/list_fuels.lua
+++ b/checks/list_fuels.lua
@@ -1,0 +1,22 @@
+-- List all registered fuels (from core.register_craft)
+
+print("Registered fuels:")
+local fuels = {}
+for itemstring, def in pairs(minetest.registered_items) do
+	local input = {
+		method = "fuel",
+		items = { itemstring },
+	}
+	local res = minetest.get_craft_result(input)
+	if res and res.time > 0 then
+		table.insert(fuels, {itemstring, res.time})
+	end
+end
+local sort_by_time = function(v1, v2)
+	return v1[2] < v2[2]
+end
+table.sort(fuels, sort_by_time)
+for f=1, #fuels do
+	-- Print the fuel name and burntime
+	print(string.format("%s (burntime=%d)", fuels[f][1], fuels[f][2]))
+end


### PR DESCRIPTION
This PR adds 2 new checker scripts for convenience.

The first one lists all cooking recipes added with `core.register_craft`: The input, output and cooktime are displayed.

The second one lists all fuels added with `core.register_craft`: The input and burntime. This list is sorted by burntime.

These scripts are helpful in games with a LOT of such recipes to discover if there are any outliers. Many crafting guides do not display fuels and cooking recipes neatly in a list format.

I’ve originally wrote this code in Repixture to verify that my recipes are correct, and my burntimes look OK. So the code has been battle-tested already.

But please do your own tests before merging.