### PR TITLE
Exclude QA block from some checks

### DIFF
--- a/checks/is_ground_content.lua
+++ b/checks/is_ground_content.lua
@@ -15,7 +15,7 @@ Recommended values for is_ground_content:
   Examples: Chests, furnaces, fences, ladders, stone bricks, etc.]]
 
 for name, def in pairs(minetest.registered_nodes) do
-	if def.is_ground_content then
+	if name ~= "unknown" and name ~= "air" and name ~= "ignore" and name ~= "qa_block:block" and def.is_ground_content then
 		print(name)
 	end
 end

--- a/checks/no_sounds.lua
+++ b/checks/no_sounds.lua
@@ -5,8 +5,8 @@
 for name, def in qa_block.pairsByKeys(minetest.registered_nodes) do
 	local complaints = {}
 	local failed = false
-	-- Air and ignore are allowed to be silent
-	if name == "air" or name == "ignore" then
+	-- Air, ignore and the QA block are allowed to be silent
+	if name == "air" or name == "ignore" or name == "qa_block:block" then
 		-- No complaints
 	
 	-- No sounds at all

--- a/checks/unobtainable_items.lua
+++ b/checks/unobtainable_items.lua
@@ -4,7 +4,7 @@
 
 local items = {}
 for item, _ in pairs(minetest.registered_items) do
-	if item ~= "unknown" and item ~= "ignore" and item ~= "air" and item ~= "" then
+	if item ~= "unknown" and item ~= "ignore" and item ~= "air" and item ~= "qa_block:block" and item ~= "" then
 		items[item] = false
 	end
 end


### PR DESCRIPTION
In the node checks like `no_sounds`, the QA block is included so it will always show up but this is pointless because the QA block is actually intended to be this way (like having no sounds).

So I added a few exceptions in the checks to exclude the QA block.