### PR TITLE
Add description and depends to mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
 name = qa_block
+title = QA Block
+description = A developer tool for modders to perform various checks, such as duplicate crafting recipes.
+optional_depends = smartfs


### PR DESCRIPTION
This PR adds the mod description, title (same as in README) and dependencies to `mod.conf`.

Because currently, the QA block triggers Luanti warnings for *only* using legacy `description.txt` and `depends.txt`. Adding those to `mod.conf` removes the warnings.

I decided to keep those 2 files tho for backwards-compatibility reasons.

Sadly, this creates a little redundancy, but there is no other way to also guarantee compatibility with old engine versions. And IMO this mod needs to be compatible with as many engine versions as possible.